### PR TITLE
#8 Detects if we're running in electron or not and loads a different storage provider based on this

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -27,6 +27,7 @@ import { ElectronFileSystemStorageProviderService } from './shared/services/stor
 import { metaReducers } from './shared/store/metaReducers';
 import { reducers } from './shared/store/reducers';
 import { effects } from './shared/store/effects';
+import storageProviderFactory from './shared/services/storage-providers/storage-provider-factory';
 
 
 // AoT requires an exported function for factories
@@ -59,7 +60,7 @@ const httpLoaderFactory = (http: HttpClient): TranslateHttpLoader =>
     }),
   ],
   providers: [
-    { provide: 'StorageProvider', useClass: ElectronFileSystemStorageProviderService}
+    { provide: 'StorageProvider', useFactory: storageProviderFactory}
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/shared/services/storage-providers/electron-file-system-storage-provider.service.ts
+++ b/src/app/shared/services/storage-providers/electron-file-system-storage-provider.service.ts
@@ -3,20 +3,29 @@ import { Episode } from '../../../episode/episode.models';
 import { emptyEpisode } from '../../../episode/episode.utils';
 import StorageProvider from './StorageProvider';
 
-// TODO: Is there an "import" way to do this?
-const {ipcRenderer} = (<any>window).require('electron');
+// SH: I had to move this down to the constructor.
+//     When doing "browser only" development, electron is not available.
+//     Thus, the call to require('electron') would throw and nothing else could work.
+//     Now, we are only making a new ElectronFileSystemStorageProviderService() if running in electron.
+//     See storage-provider-factory.ts 
+// const {ipcRenderer} = (<any>window).require('electron');
 
 @Injectable({
   providedIn: 'root'
 })
 export class ElectronFileSystemStorageProviderService implements StorageProvider {
 
-  constructor() { }
+  private ipcRenderer: any;
+
+  constructor() { 
+    const {ipcRenderer} = (<any>window).require('electron');
+    this.ipcRenderer = ipcRenderer;
+  }
 
 
   createEpisode = async (episodeLocation: string) => {
     const newEpisode = emptyEpisode();
-    const response = await ipcRenderer.invoke(
+    const response = await this.ipcRenderer.invoke(
       'file-system-create-episode',
       episodeLocation,
       newEpisode
@@ -25,14 +34,14 @@ export class ElectronFileSystemStorageProviderService implements StorageProvider
   }
 
   saveEpisode = async (episode: Episode) => {
-    const response = await ipcRenderer.invoke(
+    const response = await this.ipcRenderer.invoke(
       'file-system-save-episode',
       episode
     );
   }
 
   loadEpisode = async (episodeLocation: string) => {
-    const response = await ipcRenderer.invoke(
+    const response = await this.ipcRenderer.invoke(
       'file-system-load-episode',
       episodeLocation
     );

--- a/src/app/shared/services/storage-providers/mock-storage-provider.service.spec.ts
+++ b/src/app/shared/services/storage-providers/mock-storage-provider.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MockStorageProviderService } from './mock-storage-provider.service';
+
+describe('MockStorageProviderService', () => {
+  let service: MockStorageProviderService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(MockStorageProviderService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/storage-providers/mock-storage-provider.service.ts
+++ b/src/app/shared/services/storage-providers/mock-storage-provider.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { Episode } from '../../../episode/episode.models';
+import { emptyEpisode, emptyEpisodeInfo } from '../../../episode/episode.utils';
+import StorageProvider from './StorageProvider';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MockStorageProviderService implements StorageProvider {
+
+  constructor() { }
+  createEpisode = async (episodeLocation: string) => {
+    return emptyEpisode();
+  };
+  
+  saveEpisode = async (episode: Episode) => {
+    // Do nothing
+  };
+
+  loadEpisode = async (episodeLocation: string) => {
+    // SH: Feel free to add any mock data you want here that makes it easier to build the UI.
+    return {
+      id: "MOCK_EPISODE",
+      info: emptyEpisodeInfo(),
+      segments: {},
+      parts: {},
+      slides: {},
+      takes: {}
+    };
+  };
+}

--- a/src/app/shared/services/storage-providers/storage-provider-factory.ts
+++ b/src/app/shared/services/storage-providers/storage-provider-factory.ts
@@ -1,0 +1,17 @@
+import { ElectronFileSystemStorageProviderService } from "./electron-file-system-storage-provider.service";
+import { MockStorageProviderService } from "./mock-storage-provider.service";
+
+const storageProviderFactory = () => {
+  console.log("Determining storage provider from user agent.", navigator.userAgent);
+  if(navigator.userAgent.toLowerCase().indexOf("electron") > -1) {
+    console.log("Detected electron.");
+    return new ElectronFileSystemStorageProviderService();
+  }
+  else
+  {
+    console.log("Did not detect electron.");
+    return new MockStorageProviderService();
+  }
+}
+
+export default storageProviderFactory;


### PR DESCRIPTION
Created a new "mock-storage-provider" service. It's basically a "do nothing" storage provider.

Created a storage provider factory that is used by app.module.ts to determine if we're running in electron or not. If not, it loads the mock. No call to require('electron') ever takes place.

Of course, I had to move the call to require('electron') into the constructor of electron-file-system-storage-provider service. Which, yes... is... unusual. However, it is the only way I could figure to avoid the call to require('electron') when running in a browser.

Because the class is so small, I don't think it's that messy. But, hey... if you know a better approach, I'm all ears. :-)